### PR TITLE
Fix Dockerfile COPY ends in /

### DIFF
--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -2,7 +2,7 @@ FROM lambci/lambda:build-python3.8
 
 WORKDIR /tmp
 
-COPY titiler.*.tar.gz /tmp
+COPY titiler.*.tar.gz /tmp/
 
 # rasterio 1.2.0 wheels are built using GDAL 3.2 and PROJ 7 which we found having a
 # performance downgrade: https://github.com/developmentseed/titiler/discussions/216


### PR DESCRIPTION
Found a bug in testing that COPY commands with wildcards are supposed to point to a directory ending in / 
Was working on Mac without that for some reason.