### PR TITLE
fix test failures caused by newer morecantile version and pre-commit warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/deployment/aws/cdk/app.py
+++ b/deployment/aws/cdk/app.py
@@ -190,10 +190,7 @@ elif settings.mosaic_backend == "dynamodb://":
     stack = core.Stack()
     perms.append(
         iam.PolicyStatement(
-            actions=[
-                "dynamodb:CreateTable",
-                "dynamodb:DescribeTable",
-            ],
+            actions=["dynamodb:CreateTable", "dynamodb:DescribeTable"],
             resources=[f"arn:aws:dynamodb:{stack.region}:{stack.account}:table/*"],
         )
     )
@@ -208,7 +205,9 @@ elif settings.mosaic_backend == "dynamodb://":
                 "dynamodb:PutItem",
                 "dynamodb:BatchWriteItem",
             ],
-            resources=[f"arn:aws:dynamodb:{stack.region}:{stack.account}:table/{table_name}"],
+            resources=[
+                f"arn:aws:dynamodb:{stack.region}:{stack.account}:table/{table_name}"
+            ],
         )
     )
 

--- a/docs/examples/notebooks/Working_with_Mosaics.ipynb
+++ b/docs/examples/notebooks/Working_with_Mosaics.ipynb
@@ -1,4 +1,4 @@
-{
+/{
  "cells": [
   {
    "cell_type": "markdown",
@@ -467,7 +467,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def _get_link_by_rel(response_body: dict, rel: str) -> str:\n",
+    "def get_link_by_rel(response_body: dict, rel: str) -> str:\n",
     "    return next((x[\"href\"] for x in response_body[\"links\"] if x[\"rel\"] == rel), None)"
    ]
   },
@@ -486,7 +486,7 @@
     }
    ],
    "source": [
-    "self_link = _get_link_by_rel(response_body, \"self\")\n",
+    "self_link = get_link_by_rel(response_body, \"self\")\n",
     "print(f\"self href: {self_link}\")"
    ]
   },
@@ -513,7 +513,7 @@
     }
    ],
    "source": [
-    "tilejson_link = _get_link_by_rel(response_body, \"tilejson\")\n",
+    "tilejson_link = get_link_by_rel(response_body, \"tilejson\")\n",
     "print(f\"tilejson href: {tilejson_link}\")"
    ]
   },
@@ -561,7 +561,7 @@
     }
    ],
    "source": [
-    "mosaicjson_link = _get_link_by_rel(response_body, \"mosaicjson\")\n",
+    "mosaicjson_link = get_link_by_rel(response_body, \"mosaicjson\")\n",
     "print(f\"mosaicjson href: {mosaicjson_link}\")"
    ]
   },
@@ -580,7 +580,7 @@
     }
    ],
    "source": [
-    "tiles_link = _get_link_by_rel(response_body, \"tiles\")\n",
+    "tiles_link = get_link_by_rel(response_body, \"tiles\")\n",
     "print(f\"tiles href: {tiles_link}\")"
    ]
   },

--- a/docs/examples/notebooks/Working_with_Mosaics.ipynb
+++ b/docs/examples/notebooks/Working_with_Mosaics.ipynb
@@ -467,7 +467,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_link_by_rel(response_body: dict, rel: str) -> str:\n",
+    "def _get_link_by_rel(response_body: dict, rel: str) -> str:\n",
     "    return next((x[\"href\"] for x in response_body[\"links\"] if x[\"rel\"] == rel), None)"
    ]
   },
@@ -486,7 +486,7 @@
     }
    ],
    "source": [
-    "self_link = get_link_by_rel(response_body, \"self\")\n",
+    "self_link = _get_link_by_rel(response_body, \"self\")\n",
     "print(f\"self href: {self_link}\")"
    ]
   },
@@ -513,7 +513,7 @@
     }
    ],
    "source": [
-    "tilejson_link = get_link_by_rel(response_body, \"tilejson\")\n",
+    "tilejson_link = _get_link_by_rel(response_body, \"tilejson\")\n",
     "print(f\"tilejson href: {tilejson_link}\")"
    ]
   },
@@ -561,7 +561,7 @@
     }
    ],
    "source": [
-    "mosaicjson_link = get_link_by_rel(response_body, \"mosaicjson\")\n",
+    "mosaicjson_link = _get_link_by_rel(response_body, \"mosaicjson\")\n",
     "print(f\"mosaicjson href: {mosaicjson_link}\")"
    ]
   },
@@ -580,7 +580,7 @@
     }
    ],
    "source": [
-    "tiles_link = get_link_by_rel(response_body, \"tiles\")\n",
+    "tiles_link = _get_link_by_rel(response_body, \"tiles\")\n",
     "print(f\"tiles href: {tiles_link}\")"
    ]
   },

--- a/titiler/application/tests/routes/test_tms.py
+++ b/titiler/application/tests/routes/test_tms.py
@@ -6,7 +6,7 @@ def test_tilematrix(app):
     response = app.get("/tileMatrixSets")
     assert response.status_code == 200
     body = response.json()
-    assert len(body["tileMatrixSets"]) == 12  # morecantile has 10 defaults
+    assert len(body["tileMatrixSets"]) == 13  # morecantile has 13 defaults
     tms = list(filter(lambda m: m["id"] == "EPSG3413", body["tileMatrixSets"]))[0]
     assert tms["links"][0]["href"] == "http://testserver/tileMatrixSets/EPSG3413"
 

--- a/titiler/application/titiler/application/main.py
+++ b/titiler/application/titiler/application/main.py
@@ -85,6 +85,7 @@ def landing(request: Request):
         name="index.html", context={"request": request}, media_type="text/html",
     )
 
+
 # to run the app locally, uncomment these lines:
 # import uvicorn
 # if __name__ == "__main__":

--- a/titiler/application/titiler/application/routers/mosaic.py
+++ b/titiler/application/titiler/application/routers/mosaic.py
@@ -1,11 +1,13 @@
 """TiTiler MosaicJSON demo endpoints."""
 
 from titiler.application.custom import ColorMapParams
-from titiler.mosaic.factory import MosaicTilerFactory
 from titiler.core.resources.enums import OptionalHeader
+from titiler.mosaic.factory import MosaicTilerFactory
 
 mosaic = MosaicTilerFactory(
-    colormap_dependency=ColorMapParams, router_prefix="mosaicjson", optional_headers=[OptionalHeader.server_timing]
+    colormap_dependency=ColorMapParams,
+    router_prefix="mosaicjson",
+    optional_headers=[OptionalHeader.server_timing],
 )
 
 router = mosaic.router

--- a/titiler/core/tests/test_factories.py
+++ b/titiler/core/tests/test_factories.py
@@ -410,7 +410,7 @@ def test_TMSFactory():
     response = client.get("/tms/tileMatrixSets")
     assert response.status_code == 200
     body = response.json()
-    assert len(body["tileMatrixSets"]) == 10  # morecantile has 10 defaults
+    assert len(body["tileMatrixSets"]) == 11  # morecantile has 11 defaults
     tms = list(filter(lambda m: m["id"] == "WebMercatorQuad", body["tileMatrixSets"]))[
         0
     ]

--- a/titiler/mosaic/setup.py
+++ b/titiler/mosaic/setup.py
@@ -10,7 +10,7 @@ inst_reqs = [
     "cogeo-mosaic>=3.0,<3.1",
     "pystac-client~=0.1.1",
     "stac_pydantic",  # inherit version from pystac-client
-    "morecantile>=2.1" # also a transitive dep of cogeo-mosaic
+    "morecantile>=2.1",  # also a transitive dep of cogeo-mosaic
 ]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "pytest-asyncio", "requests"],

--- a/titiler/mosaic/setup.py
+++ b/titiler/mosaic/setup.py
@@ -10,7 +10,7 @@ inst_reqs = [
     "cogeo-mosaic>=3.0,<3.1",
     "pystac-client~=0.1.1",
     "stac_pydantic",  # inherit version from pystac-client
-    "morecantile>=2.1",  # also a transitive dep of cogeo-mosaic
+    "morecantile>=2.1.4",  # also a transitive dep of cogeo-mosaic
 ]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "pytest-asyncio", "requests"],

--- a/titiler/mosaic/tests/conftest.py
+++ b/titiler/mosaic/tests/conftest.py
@@ -5,9 +5,10 @@ from typing import Any, Dict
 
 import pytest
 from rasterio.io import MemoryFile
-from titiler.mosaic.settings import mosaic_config
-from titiler.mosaic.factory import MosaicTilerFactory
+
 from titiler.core.resources.enums import OptionalHeader
+from titiler.mosaic.factory import MosaicTilerFactory
+from titiler.mosaic.settings import mosaic_config
 
 from fastapi import FastAPI
 
@@ -25,6 +26,7 @@ def set_env(monkeypatch):
     monkeypatch.setenv("AWS_REGION", "us-west-2")
     monkeypatch.delenv("AWS_PROFILE", raising=False)
     monkeypatch.setenv("AWS_CONFIG_FILE", "/tmp/noconfigheere")
+
 
 @pytest.fixture
 def client():

--- a/titiler/mosaic/tests/test_factory.py
+++ b/titiler/mosaic/tests/test_factory.py
@@ -5,19 +5,20 @@ import tempfile
 from contextlib import contextmanager
 
 from cogeo_mosaic.backends import FileBackend
-from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.errors import NoAssetFoundError
+from cogeo_mosaic.mosaic import MosaicJSON
+from pytest import raises
 
 from titiler.core.dependencies import WebMercatorTMSParams
 from titiler.core.resources.enums import OptionalHeader
 from titiler.mosaic.factory import MosaicTilerFactory
+from titiler.mosaic.settings import mosaic_config
 
 from .conftest import DATA_DIR
 
 from fastapi import FastAPI
 
 from starlette.testclient import TestClient
-from pytest import raises
 
 assets = [os.path.join(DATA_DIR, asset) for asset in ["cog1.tif", "cog2.tif"]]
 
@@ -51,23 +52,23 @@ def test_MosaicTilerFactory():
     client = TestClient(app)
 
     with tmpmosaic() as mosaic_file:
-        response = client.get("/mosaic/", params={"url": mosaic_file}, )
+        response = client.get("/mosaic/", params={"url": mosaic_file},)
         assert response.status_code == 200
         assert response.json()["mosaicjson"]
 
-        response = client.get("/mosaic", params={"url": mosaic_file}, )
+        response = client.get("/mosaic", params={"url": mosaic_file},)
         assert response.status_code == 200
         assert response.json()["mosaicjson"]
 
-        response = client.get("/mosaic/bounds", params={"url": mosaic_file}, )
+        response = client.get("/mosaic/bounds", params={"url": mosaic_file},)
         assert response.status_code == 200
         assert response.json()["bounds"]
 
-        response = client.get("/mosaic/info", params={"url": mosaic_file}, )
+        response = client.get("/mosaic/info", params={"url": mosaic_file},)
         assert response.status_code == 200
         assert response.json()["bounds"]
 
-        response = client.get("/mosaic/info.geojson", params={"url": mosaic_file}, )
+        response = client.get("/mosaic/info.geojson", params={"url": mosaic_file},)
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/geo+json"
         assert response.json()["type"] == "Feature"
@@ -102,8 +103,8 @@ def test_MosaicTilerFactory():
         assert response.status_code == 200
         body = response.json()
         assert (
-                "http://testserver/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?url="
-                in body["tiles"][0]
+            "http://testserver/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?url="
+            in body["tiles"][0]
         )
         assert body["minzoom"] == 6
         assert body["maxzoom"] == 9
@@ -128,8 +129,9 @@ def test_MosaicTilerFactory():
 
 root = "http://testserver/mosaic"
 
-def get_link_by_rel(response_body: dict, rel: str) -> str:
-    return next((x["href"] for x in response_body["links"] if x["rel"] == rel), None)
+
+def _get_link_by_rel(response_body: dict, rel: str) -> str:
+    return next((x["href"] for x in response_body["links"] if x["rel"] == rel), "")
 
 
 def test_mosaics_basic(set_env, client):
@@ -143,10 +145,9 @@ def test_mosaics_basic(set_env, client):
 
     r = client.post(
         url="/mosaic/mosaics",
-        headers={
-            "Content-Type": "application/vnd.titiler.mosaicjson+json",
-        },
-        json=mosaicjson_data.dict(exclude_none=True))
+        headers={"Content-Type": "application/vnd.titiler.mosaicjson+json"},
+        json=mosaicjson_data.dict(exclude_none=True),
+    )
     assert r.status_code == 201
     mosaic_id = r.json()["id"]
     assert mosaic_id
@@ -154,25 +155,25 @@ def test_mosaics_basic(set_env, client):
     location_header_url = r.headers["location"]
     assert location_header_url == f"{root}/mosaics/{mosaic_id}"
 
-    assert location_header_url == get_link_by_rel(r.json(), "self")
+    assert location_header_url == _get_link_by_rel(r.json(), "self")
 
     # GET
     r = client.get(url=location_header_url)
     assert r.json()["id"] == mosaic_id
 
-    self_link = get_link_by_rel(r.json(), "self")
+    self_link = _get_link_by_rel(r.json(), "self")
     assert self_link == f"{root}/mosaics/{mosaic_id}"
 
-    mosaicjson_link = get_link_by_rel(r.json(), "mosaicjson")
+    mosaicjson_link = _get_link_by_rel(r.json(), "mosaicjson")
     assert mosaicjson_link == f"{root}/mosaics/{mosaic_id}/mosaicjson"
 
-    tilejson_link = get_link_by_rel(r.json(), "tilejson")
+    tilejson_link = _get_link_by_rel(r.json(), "tilejson")
     assert tilejson_link == f"{root}/mosaics/{mosaic_id}/tilejson.json"
 
-    tiles_link = get_link_by_rel(r.json(), "tiles")
+    tiles_link = _get_link_by_rel(r.json(), "tiles")
     assert tiles_link == f"{root}/mosaics/{mosaic_id}/tiles/{{z}}/{{x}}/{{y}}"
 
-    wmts_link = get_link_by_rel(r.json(), "wmts")
+    wmts_link = _get_link_by_rel(r.json(), "wmts")
     assert wmts_link == f"{root}/mosaics/{mosaic_id}/WMTSCapabilities.xml"
 
     # /mosaicjson
@@ -182,25 +183,38 @@ def test_mosaics_basic(set_env, client):
     # /tilejson.json
     r = client.get(url=tilejson_link)
     assert r.json()["name"] == mosaic_id
-    assert r.json()["tiles"][0] == f"{root}/mosaics/{mosaic_id}/tiles/{{z}}/{{x}}/{{y}}@1x?"
+    assert (
+        r.json()["tiles"][0]
+        == f"{root}/mosaics/{mosaic_id}/tiles/{{z}}/{{x}}/{{y}}@1x?"
+    )
 
     # tilejson with arguments
     r = client.get(url=f"{tilejson_link}?tile_format=jpg")
     assert r.json()["name"] == mosaic_id
-    assert r.json()["tiles"][0] == f"{root}/mosaics/{mosaic_id}/tiles/{{z}}/{{x}}/{{y}}@1x.jpg?"
+    assert (
+        r.json()["tiles"][0]
+        == f"{root}/mosaics/{mosaic_id}/tiles/{{z}}/{{x}}/{{y}}@1x.jpg?"
+    )
 
     r = client.get(url=f"{tilejson_link}?tile_scale=2")
     assert r.json()["name"] == mosaic_id
-    assert r.json()["tiles"][0] == f"{root}/mosaics/{mosaic_id}/tiles/{{z}}/{{x}}/{{y}}@2x?"
+    assert (
+        r.json()["tiles"][0]
+        == f"{root}/mosaics/{mosaic_id}/tiles/{{z}}/{{x}}/{{y}}@2x?"
+    )
 
     # /tiles
 
-    single_tile_link = tiles_link.replace("{z}", "7").replace("{x}", "37").replace("{y}", "45")
+    single_tile_link = (
+        tiles_link.replace("{z}", "7").replace("{x}", "37").replace("{y}", "45")
+    )
     r = client.get(url=single_tile_link)
     assert r.status_code == 200
 
     with raises(NoAssetFoundError):
-        bad_single_tile_link = tiles_link.replace("{z}", "10").replace("{x}", "10").replace("{y}", "10")
+        bad_single_tile_link = (
+            tiles_link.replace("{z}", "10").replace("{x}", "10").replace("{y}", "10")
+        )
         r = client.get(url=bad_single_tile_link)
         assert r.status_code == 404
 
@@ -214,10 +228,9 @@ def test_mosaics_basic(set_env, client):
 
     r = client.put(
         url=self_link,
-        headers={
-            "Content-Type": "application/vnd.titiler.mosaicjson+json",
-        },
-        json=mosaicjson_data.dict(exclude_none=True))
+        headers={"Content-Type": "application/vnd.titiler.mosaicjson+json"},
+        json=mosaicjson_data.dict(exclude_none=True),
+    )
     assert r.status_code == 204
 
     r = client.get(url=mosaicjson_link)
@@ -225,7 +238,9 @@ def test_mosaics_basic(set_env, client):
     assert r.json()["name"] == "my mosaic"
 
     r = client.delete(url=self_link)
-    assert r.status_code == 405  # because we're using the in-memory db instead of dynamodb
+    assert (
+        r.status_code == 405
+    )  # because we're using the in-memory db instead of dynamodb
 
     # note: in cogeo-mosaic, the cache is not flushed on delete, so the old entry still exists for 5 min
 
@@ -244,10 +259,9 @@ def test_mosaics_errors_not_found(set_env, client):
 
     r = client.put(
         url="/mosaic/mosaics/ABC",
-        headers={
-            "Content-Type": "application/vnd.titiler.mosaicjson+json",
-        },
-        json={})
+        headers={"Content-Type": "application/vnd.titiler.mosaicjson+json"},
+        json={},
+    )
     assert r.status_code == 404
 
     r = client.delete(url="/mosaic/mosaics/ABC")
@@ -265,66 +279,53 @@ def test_mosaics_create(set_env, client):
 
     r = client.post(
         url="/mosaic/mosaics",
-        headers={
-            "Content-Type": "",
-        },
-        json=mosaicjson_data.dict(exclude_none=True))
+        headers={"Content-Type": ""},
+        json=mosaicjson_data.dict(exclude_none=True),
+    )
     assert r.status_code == 201
 
     r = client.post(
         url="/mosaic/mosaics",
-        headers={
-            "Content-Type": "application/json",
-        },
-        json=mosaicjson_data.dict(exclude_none=True))
+        headers={"Content-Type": "application/json"},
+        json=mosaicjson_data.dict(exclude_none=True),
+    )
     assert r.status_code == 201
 
     r = client.post(
         url="/mosaic/mosaics",
-        headers={
-            "Content-Type": "application/json; charset=utf-8",
-        },
-        json=mosaicjson_data.dict(exclude_none=True))
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        json=mosaicjson_data.dict(exclude_none=True),
+    )
     assert r.status_code == 201
 
     r = client.post(
         url="/mosaic/mosaics",
-        headers={
-            "Content-Type": "application/vnd.titiler.mosaicjson+json",
-        },
-        json=mosaicjson_data.dict(exclude_none=True))
+        headers={"Content-Type": "application/vnd.titiler.mosaicjson+json"},
+        json=mosaicjson_data.dict(exclude_none=True),
+    )
     assert r.status_code == 201
 
     r = client.post(
         url="/mosaic/mosaics",
-        headers={
-            "Content-Type": "application/vnd.titiler.urls+json"
-        },
-        json={"urls": assets})
+        headers={"Content-Type": "application/vnd.titiler.urls+json"},
+        json={"urls": assets},
+    )
     assert r.status_code == 201
 
     r = client.post(
         url="/mosaic/mosaics",
-        headers={
-            "Content-Type": "application/vnd.titiler.stac-api-query+json"
-        },
+        headers={"Content-Type": "application/vnd.titiler.stac-api-query+json"},
         json={
             "stac_api_root": "https://earth-search.aws.element84.com/v0",
             "name": "foo",
             "description": "bar",
             "attribution": "shmattribution",
             "asset_name": "visual",
-            "collections": [
-                "sentinel-s2-l2a-cogs"
-            ],
+            "collections": ["sentinel-s2-l2a-cogs"],
             "datetime": "2021-04-20T00:00:00Z/2021-04-21T02:00:00Z",
-            "bbox": [
-                20,
-                20,
-                21,
-                21
-            ]
-        })
+            "bbox": [20, 20, 21, 21],
+        },
+    )
     assert r.status_code == 201
 
     def test_mosaics_create_errors(set_env):
@@ -345,31 +346,26 @@ def test_mosaics_create(set_env, client):
         # invalid MosaicJSON
         r = client.post(
             url="/mosaic/mosaics",
-            headers={
-                "Content-Type": "application/json",
-            },
-            json={})
+            headers={"Content-Type": "application/json"},
+            json={},
+        )
         assert r.status_code == 400
 
         # too many urls
         r = client.post(
             url="/mosaic/mosaics",
-            headers={
-                "Content-Type": "application/vnd.titiler.urls+json"
-            },
-            json={"urls": [{str(x): str(x)} for x in range(101)]})
+            headers={"Content-Type": "application/vnd.titiler.urls+json"},
+            json={"urls": [{str(x): str(x)} for x in range(101)]},
+        )
         assert r.status_code == 400
 
         # too many results from STAC query
         r = client.post(
             url="/mosaic/mosaics",
-            headers={
-                "Content-Type": "application/vnd.titiler.stac-api-query+json"
-            },
+            headers={"Content-Type": "application/vnd.titiler.stac-api-query+json"},
             json={
                 "stac_api_root": "https://earth-search.aws.element84.com/v0",
-                "collections": [
-                    "sentinel-s2-l2a-cogs"
-                ]
-            })
+                "collections": ["sentinel-s2-l2a-cogs"],
+            },
+        )
         assert r.status_code == 400

--- a/titiler/mosaic/titiler/mosaic/resources/models.py
+++ b/titiler/mosaic/titiler/mosaic/resources/models.py
@@ -1,12 +1,11 @@
 """Titiler.mosaic Models."""
 
-from cogeo_mosaic.mosaic import MosaicJSON
+import re
 from typing import List, Optional
 
-from stac_pydantic.api import Search
 from pydantic import BaseModel, validator
+from stac_pydantic.api import Search
 
-import re
 
 def to_camel(snake_str: str) -> str:
     """
@@ -33,9 +32,12 @@ class MosaicEntity(BaseModel):
     links: List[Link]
 
 
-rfc3339_regex_str = r"^(\d\d\d\d)\-(\d\d)\-(\d\d)(T|t)" \
-                    r"(\d\d):(\d\d):(\d\d)(\.\d+)?(Z|([-+])(\d\d):(\d\d))$"
+rfc3339_regex_str = (
+    r"^(\d\d\d\d)\-(\d\d)\-(\d\d)(T|t)"
+    r"(\d\d):(\d\d):(\d\d)(\.\d+)?(Z|([-+])(\d\d):(\d\d))$"
+)
 rfc3339_regex = re.compile(rfc3339_regex_str)
+
 
 class StacApiQueryRequestBody(Search):
     """Common request params for MosaicJSON CRUD operations"""
@@ -52,10 +54,12 @@ class StacApiQueryRequestBody(Search):
     # overriding limit so we can tell if it's defined or not
     limit: Optional[int]
 
-    # copied from Search to fix https://github.com/stac-utils/stac-pydantic/issues/78
-    # override
     @validator("datetime")
     def validate_datetime(cls, v):
+        """
+        datetime validation
+        overrides default validation due to issue https://github.com/stac-utils/stac-pydantic/issues/78
+        """
         if "/" in v:
             values = v.split("/")
         else:
@@ -83,7 +87,10 @@ class StacApiQueryRequestBody(Search):
         #         )
         return v
 
+
 class UrisRequestBody(BaseModel):
+    """model for a source body to create a mosaicjson"""
+
     # option 2 - a list of files and min/max zoom
     urls: List[str]
     minzoom: Optional[int] = None
@@ -95,15 +102,24 @@ class UrisRequestBody(BaseModel):
 
 
 class TooManyResultsException(Exception):
+    """exception when there are too many STAC API results to generate a mosaicjson"""
+
     def __init__(self, message):
+        """init"""
         self.message = message
 
 
 class StoreException(Exception):
+    """exception when there is a problem storing the mosaicjson in the datastore"""
+
     def __init__(self, message):
+        """init"""
         self.message = message
 
 
 class UnsupportedOperationException(Exception):
+    """exception for unsupported operation"""
+
     def __init__(self, message):
+        """init"""
         self.message = message


### PR DESCRIPTION
1. version 2.1.4 added additional tilesetmatrix options, which causes several tests to fail. Fixed those tests by updating the expected counts.
2. the github pre-commit hooks were failing because of numerous minor issues, like unused imports, f-strings without replacements, etc. Fixed all of these so the pre-commit hooks run cleanly now.

next step will be to actually update from upstream